### PR TITLE
feat: add update support for logs

### DIFF
--- a/src/application/log/LogApplicationService.ts
+++ b/src/application/log/LogApplicationService.ts
@@ -12,6 +12,13 @@ export class LogApplicationService {
     return this.port.createLog(log);
   }
 
+  async updateLog(
+    id: number,
+    log: Partial<Omit<Log, "id" | "fecha">>
+  ): Promise<Log | null> {
+    return this.port.updateLog(id, log);
+  }
+
   async deleteLog(id: number): Promise<boolean> {
     return this.port.deleteLog(id);
   }

--- a/src/domain/log/LogPort.ts
+++ b/src/domain/log/LogPort.ts
@@ -2,6 +2,10 @@ import { Log } from "./Log";
 
 export interface LogPort {
   createLog(log: Omit<Log, "id" | "fecha">): Promise<number>;
+  updateLog(
+    id: number,
+    log: Partial<Omit<Log, "id" | "fecha">>
+  ): Promise<Log | null>;
   deleteLog(id: number): Promise<boolean>;
   getLogById(id: number): Promise<Log | null>;
   getAllLogs(): Promise<Log[]>;

--- a/src/infrastructure/adapter/LogAdapter.ts
+++ b/src/infrastructure/adapter/LogAdapter.ts
@@ -35,6 +35,27 @@ export class LogAdapter implements LogPort {
     return savedLog.id;
   }
 
+  async updateLog(
+    id: number,
+    log: Partial<Omit<Log, "id" | "fecha">>
+  ): Promise<Log | null> {
+    const existing = await this.logRepository.findOne({ where: { id } });
+    if (!existing) return null;
+
+    if (log.usuarioId !== undefined) {
+      existing.usuarioId = log.usuarioId;
+    }
+    if (log.accion !== undefined) {
+      existing.accion = log.accion;
+    }
+    if (log.entidad !== undefined) {
+      existing.entidad = log.entidad;
+    }
+
+    const saved = await this.logRepository.save(existing);
+    return this.toDomain(saved);
+  }
+
   async deleteLog(id: number): Promise<boolean> {
     const result = await this.logRepository.delete(id);
     return result.affected !== 0;

--- a/src/infrastructure/controller/LogController.ts
+++ b/src/infrastructure/controller/LogController.ts
@@ -34,6 +34,53 @@ export class LogController {
     }
   }
 
+  static async update(request: Request, response: Response): Promise<Response> {
+    try {
+      const id = Number(request.params.id);
+      if (Number.isNaN(id)) {
+        return response.status(400).json({ error: "ID inválido" });
+      }
+
+      const { usuarioId, accion, entidad } = request.body ?? {};
+      const updates: Partial<{ usuarioId: number; accion: string; entidad: string }> = {};
+
+      if (usuarioId !== undefined) {
+        const parsedUsuarioId = Number(usuarioId);
+        if (Number.isNaN(parsedUsuarioId)) {
+          return response.status(400).json({ error: "usuarioId inválido" });
+        }
+        updates.usuarioId = parsedUsuarioId;
+      }
+
+      if (accion !== undefined) {
+        if (typeof accion !== "string" || !accion.trim()) {
+          return response.status(400).json({ error: "accion inválida" });
+        }
+        updates.accion = accion;
+      }
+
+      if (entidad !== undefined) {
+        if (typeof entidad !== "string" || !entidad.trim()) {
+          return response.status(400).json({ error: "entidad inválida" });
+        }
+        updates.entidad = entidad;
+      }
+
+      if (Object.keys(updates).length === 0) {
+        return response.status(400).json({ error: "No hay datos para actualizar" });
+      }
+
+      const updatedLog = await logService.updateLog(id, updates);
+      if (!updatedLog) {
+        return response.status(404).json({ error: "Log no encontrado" });
+      }
+
+      return response.status(200).json(updatedLog);
+    } catch (err) {
+      return response.status(500).json({ error: "Error al actualizar log" });
+    }
+  }
+
   static async delete(request: Request, response: Response): Promise<Response> {
     try {
       const deleted = await logService.deleteLog(Number(request.params.id));

--- a/src/infrastructure/routes/log_routes.ts
+++ b/src/infrastructure/routes/log_routes.ts
@@ -6,6 +6,7 @@ const router = Router();
 router.post("/", LogController.create);
 router.get("/", LogController.getAll);
 router.get("/:id", LogController.getById);
+router.put("/:id", LogController.update);
 router.delete("/:id", LogController.delete);
 
 export default router;

--- a/src/infrastructure/web/app.ts
+++ b/src/infrastructure/web/app.ts
@@ -3,7 +3,7 @@ import bodyParser from "body-parser";
 import categoriaRoutes from "../routes/categoria_routes";
 import rolRoutes from "../routes/rol_routes";
 import notificacionRoutes from "../routes/notificacion_routes";
-import logRoutes from "../routes/rol_routes";
+import logRoutes from "../routes/log_routes";
 import userRoutes from "../routes/user_routes";
 import denunciaRoutes from "../routes/denuncia_routes";
 
@@ -14,7 +14,7 @@ app.use(bodyParser.json());
 app.use("/categorias", categoriaRoutes);
 app.use("/roles", rolRoutes);
 app.use("/notificaciones", notificacionRoutes);
-app.use("/log",logRoutes);
+app.use("/log", logRoutes);
 app.use("/usuarios", userRoutes);
 app.use("/denuncias", denunciaRoutes);
 

--- a/src/tests/log.controller.test.ts
+++ b/src/tests/log.controller.test.ts
@@ -1,0 +1,78 @@
+jest.mock("../infrastructure/adapter/LogAdapter", () => ({
+  LogAdapter: jest.fn().mockImplementation(() => ({})),
+}));
+
+import { LogController } from "../infrastructure/controller/LogController";
+import { LogApplicationService } from "../application/log/LogApplicationService";
+import { Request, Response } from "express";
+
+describe("LogController.update", () => {
+  const buildResponse = () => {
+    const res: Partial<Response> = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res as Response;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("debe rechazar actualizaciones sin datos", async () => {
+    const req = {
+      params: { id: "1" },
+      body: {},
+    } as unknown as Request;
+    const res = buildResponse();
+
+    await LogController.update(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "No hay datos para actualizar" });
+  });
+
+  test("debe actualizar y devolver el log", async () => {
+    const req = {
+      params: { id: "2" },
+      body: { accion: "Cambio" },
+    } as unknown as Request;
+    const res = buildResponse();
+
+    const spy = jest
+      .spyOn(LogApplicationService.prototype, "updateLog")
+      .mockResolvedValue({
+        id: 2,
+        usuarioId: 1,
+        accion: "Cambio",
+        entidad: "usuarios",
+        fecha: new Date(),
+      });
+
+    await LogController.update(req, res);
+
+    expect(spy).toHaveBeenCalledWith(2, { accion: "Cambio" });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 2, accion: "Cambio" })
+    );
+  });
+
+  test("debe responder 404 cuando el log no existe", async () => {
+    const req = {
+      params: { id: "3" },
+      body: { accion: "Cambio" },
+    } as unknown as Request;
+    const res = buildResponse();
+
+    jest.spyOn(LogApplicationService.prototype, "updateLog").mockResolvedValue(null);
+
+    await LogController.update(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: "Log no encontrado" });
+  });
+});

--- a/src/tests/log.service.test.ts
+++ b/src/tests/log.service.test.ts
@@ -9,6 +9,7 @@ describe("Pruebas de LogApplicationService", () => {
   beforeEach(() => {
     mockRepo = {
       createLog: jest.fn(),
+      updateLog: jest.fn(),
       deleteLog: jest.fn(),
       getLogById: jest.fn(),
       getAllLogs: jest.fn(),
@@ -39,5 +40,31 @@ describe("Pruebas de LogApplicationService", () => {
 
     const log = await service.getLogById(1);
     expect(log?.accion).toBe("Creación de usuario");
+  });
+
+  test("Debe actualizar un log existente", async () => {
+    const updatedLog = {
+      id: 1,
+      usuarioId: 6,
+      accion: "Actualización de perfil",
+      entidad: "usuarios",
+      fecha: new Date(),
+    } as LogEntity;
+
+    (mockRepo.updateLog as jest.Mock).mockResolvedValue(updatedLog);
+
+    const result = await service.updateLog(1, { accion: "Actualización de perfil" });
+
+    expect(mockRepo.updateLog).toHaveBeenCalledWith(1, { accion: "Actualización de perfil" });
+    expect(result).toEqual(updatedLog);
+  });
+
+  test("Debe retornar null si el log a actualizar no existe", async () => {
+    (mockRepo.updateLog as jest.Mock).mockResolvedValue(null);
+
+    const result = await service.updateLog(99, { accion: "No existe" });
+
+    expect(mockRepo.updateLog).toHaveBeenCalledWith(99, { accion: "No existe" });
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add updateLog methods to the log port, service, and adapter using repository save
- implement the log controller update endpoint and expose it through the router
- correct log route wiring and add unit tests for the update flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc3fab46c483248acb8dacd7bfa588