### PR TITLE
Add SonarQube configuration and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests with coverage
+        run: npm test -- --coverage
+
+      - name: SonarQube analysis
+        if: ${{ secrets.SONAR_TOKEN != '' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+        run: npm run sonar

--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ npm test
 ```
 Incluye pruebas de transiciones de voto.
 
+## Análisis de calidad con SonarQube
+
+1. Configura el secret `SONAR_TOKEN` en el repositorio (token generado desde tu instancia de SonarQube/SonarCloud) y, si usas un host distinto a SonarCloud, define la variable `SONAR_HOST_URL`.
+2. Ejecuta el análisis localmente con:
+   ```
+   SONAR_TOKEN=xxxxxxxx npm run sonar
+   ```
+   El workflow de CI lanza el mismo comando y sólo se ejecuta cuando `SONAR_TOKEN` está presente.
+
+### Interpretación del reporte
+- **Quality Gate**: debe estar en estado `Passed`. Si está en `Failed`, consulta las métricas resaltadas como incumplidas.
+- **Cobertura** (`Coverage`): objetivo mínimo 80% en nuevo código. Revisa los archivos listados en la pestaña Coverage para priorizar pruebas adicionales.
+- **Bugs y Vulnerabilidades**: los issues de severidad `Blocker` o `Critical` deben resolverse antes de aprobar cambios.
+- **Code Smells**: acepta un máximo de deuda técnica equivalente a 5 minutos por archivo nuevo/modificado.
+- **Duplicaciones**: mantener el porcentaje de duplicación por debajo del 3% en los archivos modificados.
+
+Cumpliendo estas reglas mínimas el pipeline se mantendrá en verde y el proyecto conservará un estado saludable.
+
 ## Comentarios recomendados
 En `DenunciaAdapter.vote()` agregar referencia “Ver README sección Votos”. Eliminar comentarios viejos de “hotScore”.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "jest"
+    "test": "jest",
+    "sonar": "sonar-scanner"
   },
   "keywords": [],
   "author": "",
@@ -35,6 +36,7 @@
     "jest": "^30.1.3",
     "ts-jest": "^29.4.1",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "sonarqube-scanner": "^2.8.2"
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.projectKey=speakup-backend
+sonar.projectName=SpeakUp Backend
+sonar.projectVersion=1.0.0
+sonar.sourceEncoding=UTF-8
+sonar.sources=src
+sonar.tests=src
+sonar.test.inclusions=**/*.spec.ts,**/*.test.ts
+sonar.exclusions=**/*.spec.ts,**/*.test.ts,dist/**,node_modules/**
+sonar.coverage.exclusions=**/*.spec.ts,**/*.test.ts
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.typescript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Summary
- add a SonarQube configuration file and npm script to run the scanner
- extend the GitHub Actions workflow to execute tests and trigger the Sonar analysis when a token secret is provided
- document how to launch the scan and the minimum quality rules expected from the report

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc403382248324a5775a29acb17c8f