### PR TITLE
Add health endpoint and test

### DIFF
--- a/src/infrastructure/bootstrap/server.ts
+++ b/src/infrastructure/bootstrap/server.ts
@@ -1,26 +1,6 @@
-import express from "express";
-import userRoutes from "../routes/user_routes";
-import denunciaRoutes from "../routes/denuncia_routes";
-import logRoutes from "../routes/log_routes";
-import categoriaRoutes from "../routes/categoria_routes";
-import rolRoutes from "../routes/rol_routes";
-import notificacionRoutes from "../routes/notificacion_routes";
 import { ENV } from "../config/env";
 import { AppDataSource } from "../config/database"; // 👈 importa tu datasource
-import cors from "cors";
-
-const app = express();
-app.use(cors()); // Permite peticiones desde otros orígenes
-app.use(express.json()); // <-- Esto permite leer req.body
-
-
-// Rutas
-app.use("/usuarios", userRoutes);
-app.use("/denuncias", denunciaRoutes);
-app.use("/logs", logRoutes);
-app.use("/categorias", categoriaRoutes);
-app.use("/roles", rolRoutes);
-app.use("/notificaciones", notificacionRoutes);
+import app from "../web/app";
 
 // Inicializa la conexión con la BD y luego arranca el server
 AppDataSource.initialize()

--- a/src/infrastructure/web/app.ts
+++ b/src/infrastructure/web/app.ts
@@ -1,23 +1,36 @@
 import express from "express";
-import bodyParser from "body-parser";
+import cors from "cors";
 import categoriaRoutes from "../routes/categoria_routes";
 import rolRoutes from "../routes/rol_routes";
 import notificacionRoutes from "../routes/notificacion_routes";
-import logRoutes from "../routes/rol_routes";
+import logRoutes from "../routes/log_routes";
 import userRoutes from "../routes/user_routes";
 import denunciaRoutes from "../routes/denuncia_routes";
+import { AppDataSource } from "../config/database";
 
 const app = express();
-app.use(bodyParser.json());
+
+app.use(cors());
+app.use(express.json());
 
 // Rutas
 app.use("/categorias", categoriaRoutes);
 app.use("/roles", rolRoutes);
 app.use("/notificaciones", notificacionRoutes);
-app.use("/log",logRoutes);
+app.use("/logs", logRoutes);
 app.use("/usuarios", userRoutes);
 app.use("/denuncias", denunciaRoutes);
 
-app.listen(4000, () => {
-  console.log("Servidor corriendo en http://localhost:4000");
+app.get("/health", (_req, res) => {
+  const payload: { status: string; database?: "connected" | "disconnected" } = {
+    status: "ok",
+  };
+
+  if (typeof AppDataSource?.isInitialized === "boolean") {
+    payload.database = AppDataSource.isInitialized ? "connected" : "disconnected";
+  }
+
+  res.status(200).json(payload);
 });
+
+export default app;

--- a/src/tests/health.endpoint.test.ts
+++ b/src/tests/health.endpoint.test.ts
@@ -1,0 +1,77 @@
+import http from "http";
+import app from "../infrastructure/web/app";
+
+describe("GET /health", () => {
+  it("responds with 200 and an ok status", async () => {
+    const server = http.createServer(app);
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, resolve);
+    });
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("Unable to determine server address");
+    }
+
+    try {
+      const response = await makeRequest(address.port, "/health");
+
+      expect(response.status).toBe(200);
+      expect(response.body ?? {}).toMatchObject({ status: "ok" });
+      if (response.body?.database) {
+        expect(["connected", "disconnected"]).toContain(response.body.database);
+      }
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    }
+  });
+});
+
+type HealthPayload = { status?: string; database?: string };
+
+function makeRequest(port: number, path: string): Promise<{ status: number; body: HealthPayload | undefined }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method: "GET",
+      },
+      (res) => {
+        const chunks: Uint8Array[] = [];
+
+        res.on("data", (chunk) => {
+          chunks.push(chunk);
+        });
+
+        res.on("end", () => {
+          try {
+            const payloadString = Buffer.concat(chunks).toString("utf-8");
+            const body = payloadString ? JSON.parse(payloadString) : undefined;
+            resolve({ status: res.statusCode ?? 0, body });
+          } catch (error) {
+            reject(error);
+          }
+        });
+      }
+    );
+
+    req.on("error", (error) => {
+      reject(error);
+    });
+
+    req.end();
+  });
+}


### PR DESCRIPTION
## Summary
- export the Express app setup and expose a new /health route that reports optional database status
- bootstrap the HTTP server from the existing app instance to support reuse in tests
- cover the health endpoint with an integration test that exercises the express handler via HTTP

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cc40345ff883248711cc4f25d9dab2