### PR TITLE
Remove duplicate log route mounts

### DIFF
--- a/src/infrastructure/web/app.ts
+++ b/src/infrastructure/web/app.ts
@@ -77,10 +77,8 @@ app.use("/categorias", categoriaRoutes);
 app.use("/roles", rolRoutes);
 app.use("/notificaciones", notificacionRoutes);
 app.use("/logs", logRoutes);
-app.use("/log",logRoutes);
-app.use("/usuarios/login", loginLimiter);
-app.use("/logs", logRoutes);
 app.use("/log", logRoutes);
+app.use("/usuarios/login", loginLimiter);
 
 app.use("/usuarios", userRoutes);
 app.use("/denuncias", denunciasLimiter, denunciaRoutes);


### PR DESCRIPTION
## Summary
- ensure the log routes are only mounted once per prefix to avoid duplicate registrations

## Testing
- npm test *(fails: jest command not available and npm install blocked by 403 fetching sonarqube-scanner)*

------
https://chatgpt.com/codex/tasks/task_e_68cc531fd4108324aaecad4422d64f1e