### PR TITLE
Add PUT endpoint to logs specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Denuncias:
 - GET /denuncias/:id
 - POST /denuncias/:id/vote  (value: -1 | 0 | 1)
 
+Logs:
+- GET /logs
+- POST /logs
+- GET /logs/:id
+- PUT /logs/:id *(actualiza campos editables como `accion`, `entidad`, `usuarioId` o `fecha`)*
+- DELETE /logs/:id
+
 ## Votos (resumen)
 Transiciones y efecto en score (ver tabla completa abajo):
 0→1 (+1), 1→0 (-1), 1→-1 (-2), etc.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1317,6 +1317,60 @@
           }
         }
       },
+      "put": {
+        "tags": ["Logs"],
+        "summary": "Actualizar log",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateLogInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Log actualizado",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Log" }
+              }
+            }
+          },
+          "400": {
+            "description": "Datos inválidos para actualizar log",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ValidationErrorResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "Log no encontrado",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Error al actualizar log",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "tags": ["Logs"],
         "summary": "Eliminar log",
@@ -1589,6 +1643,15 @@
           "entidad": { "type": "string" }
         },
         "required": ["usuarioId", "accion", "entidad"]
+      },
+      "UpdateLogInput": {
+        "type": "object",
+        "properties": {
+          "usuarioId": { "type": "integer", "format": "int64" },
+          "accion": { "type": "string" },
+          "entidad": { "type": "string" },
+          "fecha": { "type": "string", "format": "date-time" }
+        }
       },
       "LogCreatedResponse": {
         "type": "object",


### PR DESCRIPTION
## Summary
- add the PUT /logs/{id} operation to the OpenAPI specification including request and response schemas
- document the new UpdateLogInput schema for editable log fields
- extend the README endpoint list to mention the new log update endpoint

## Testing
- node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('docs/openapi.json','utf8'));"
- npm install (fails: registry blocks sonarqube-scanner download)
- npm install --omit=dev (fails: registry blocks sonarqube-scanner download)


------
https://chatgpt.com/codex/tasks/task_e_68cc539b13948324819f2701a42bd4f5