### PR TITLE
Use JWT_SECRET configuration consistently

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,5 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=SpeakUp
 PORT=4000
+JWT_SECRET=dev_super_secreto
+NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ NODE_ENV=development
 ```
 Puedes cambiar estos valores directamente sin pasos extra.
 
+> **Nota:** En producción (o cualquier entorno distinto a `development`) debes definir explícitamente `JWT_SECRET`; el valor anterior solo se usa como respaldo local.
+
 ## Instalación rápida
 ```
 npm install

--- a/src/application/user/AuthApplication.ts
+++ b/src/application/user/AuthApplication.ts
@@ -1,13 +1,13 @@
 import jwt from "jsonwebtoken";
+import { ENV } from "../../infrastructure/config/env";
 
-const JWT_KEY = process.env.JWT_KEY || "HABIAUNAVEZUNPATOQUEIBACANTANDOALEGREMENTE";
+const JWT_SECRET = ENV.JWT_SECRET;
 
 export class AuthApplication {
   static generateToken(payload: object): string {
-    return jwt.sign(payload, JWT_KEY, { expiresIn: "1h" });
+    return jwt.sign(payload, JWT_SECRET, { expiresIn: "1h" });
   }
-
   static verifyToken(token: string): any {
-    return jwt.verify(token, JWT_KEY);
+    return jwt.verify(token, JWT_SECRET);
   }
 }

--- a/src/infrastructure/config/env.ts
+++ b/src/infrastructure/config/env.ts
@@ -1,12 +1,27 @@
 import dotenv from "dotenv";
+
 dotenv.config();
 
+const DEFAULT_DEV_JWT_SECRET = "dev_super_secreto";
+const NODE_ENV = process.env.NODE_ENV || "development";
+const isDevelopment = NODE_ENV === "development";
+
+const jwtSecret =
+  process.env.JWT_SECRET || (isDevelopment ? DEFAULT_DEV_JWT_SECRET : undefined);
+
+if (!jwtSecret) {
+  throw new Error(
+    "JWT_SECRET environment variable must be defined (no fallback available outside development)."
+  );
+}
+
 export const ENV = {
-    PORT: process.env.PORT || 4000,
-    DB_USER: process.env.DB_USER || "postgres",
-    DB_PASS: process.env.DB_PASS || "postgres",
-    DB_NAME: process.env.DB_NAME || "SpeakUp",
-    DB_HOST: process.env.DB_HOST || "localhost",
-    DB_PORT: Number(process.env.DB_PORT) || 5432,
-    JWT_SECRET: process.env.JWT_SECRET || "supersecret",
+  PORT: process.env.PORT || 4000,
+  DB_USER: process.env.DB_USER || "postgres",
+  DB_PASS: process.env.DB_PASS || "postgres",
+  DB_NAME: process.env.DB_NAME || "SpeakUp",
+  DB_HOST: process.env.DB_HOST || "localhost",
+  DB_PORT: Number(process.env.DB_PORT) || 5432,
+  JWT_SECRET: jwtSecret,
+  NODE_ENV,
 };

--- a/src/infrastructure/web/AuthMiddleware.ts
+++ b/src/infrastructure/web/AuthMiddleware.ts
@@ -1,8 +1,9 @@
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
+import { ENV } from "../config/env";
 
 // Debe coincidir con el utilizado en AuthApplication.ts
-const JWT_KEY = process.env.JWT_KEY || "HABIAUNAVEZUNPATOQUEIBACANTANDOALEGREMENTE";
+const JWT_SECRET = ENV.JWT_SECRET;
 
 export interface AuthRequest extends Request {
   user?: { id: number; role?: string };
@@ -15,7 +16,7 @@ export function requireAuth(req: AuthRequest, res: Response, next: NextFunction)
   }
   const token = header.substring(7);
   try {
-    const payload: any = jwt.verify(token, JWT_KEY);
+    const payload: any = jwt.verify(token, JWT_SECRET);
     console.log('[auth] payload user =>', payload);
     // Mapeamos id (si el payload por alguna razón trae userId, lo aceptamos también)
     const userId = payload.id ?? payload.userId;


### PR DESCRIPTION
## Summary
- replace JWT_KEY usage with JWT_SECRET across authentication helpers and middleware
- centralize JWT secret resolution in env config with a development-only fallback and error otherwise
- document the JWT_SECRET requirement and update the sample .env values

## Testing
- npm test *(fails: jest not found because dependencies could not be installed due to 403 on sonarqube-scanner)*

------
https://chatgpt.com/codex/tasks/task_e_68cc579647d883248bce3c70c4c5610c