### PR TITLE
Restringe actualización de fecha en logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Logs:
 - GET /logs
 - POST /logs
 - GET /logs/:id
-- PUT /logs/:id *(actualiza campos editables como `accion`, `entidad`, `usuarioId` o `fecha`)*
+- PUT /logs/:id *(actualiza campos editables como `accion`, `entidad` o `usuarioId`)*
 - DELETE /logs/:id
 
 ## Votos (resumen)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1649,8 +1649,7 @@
         "properties": {
           "usuarioId": { "type": "integer", "format": "int64" },
           "accion": { "type": "string" },
-          "entidad": { "type": "string" },
-          "fecha": { "type": "string", "format": "date-time" }
+          "entidad": { "type": "string" }
         }
       },
       "LogCreatedResponse": {

--- a/src/application/log/LogApplicationService.ts
+++ b/src/application/log/LogApplicationService.ts
@@ -1,6 +1,13 @@
 import { Log } from "../../domain/log/Log";
 import { LogPort } from "../../domain/log/LogPort";
 
+export class FechaNoEditableError extends Error {
+  constructor() {
+    super("El campo fecha no puede modificarse");
+    this.name = "FechaNoEditableError";
+  }
+}
+
 export class LogApplicationService {
   private port: LogPort;
 
@@ -16,7 +23,26 @@ export class LogApplicationService {
     id: number,
     log: Partial<Omit<Log, "id" | "fecha">>
   ): Promise<Log | null> {
-    return this.port.updateLog(id, log);
+    const logConFecha = log as Partial<Log>;
+
+    if (logConFecha.fecha !== undefined) {
+      throw new FechaNoEditableError();
+    }
+
+    const { usuarioId, accion, entidad } = log;
+    const payload: Partial<Omit<Log, "id" | "fecha">> = {};
+
+    if (usuarioId !== undefined) {
+      payload.usuarioId = usuarioId;
+    }
+    if (accion !== undefined) {
+      payload.accion = accion;
+    }
+    if (entidad !== undefined) {
+      payload.entidad = entidad;
+    }
+
+    return this.port.updateLog(id, payload);
   }
 
   async deleteLog(id: number): Promise<boolean> {

--- a/src/infrastructure/controller/LogController.ts
+++ b/src/infrastructure/controller/LogController.ts
@@ -1,5 +1,8 @@
 import { Request, Response } from "express";
-import { LogApplicationService } from "../../application/log/LogApplicationService";
+import {
+  FechaNoEditableError,
+  LogApplicationService,
+} from "../../application/log/LogApplicationService";
 import { LogAdapter } from "../adapter/LogAdapter";
 
 const logService = new LogApplicationService(new LogAdapter());
@@ -41,7 +44,13 @@ export class LogController {
         return response.status(400).json({ error: "ID inválido" });
       }
 
-      const { usuarioId, accion, entidad } = request.body ?? {};
+      const { usuarioId, accion, entidad, fecha } = request.body ?? {};
+
+      if (fecha !== undefined) {
+        return response
+          .status(400)
+          .json({ error: "El campo fecha no puede modificarse" });
+      }
       const updates: Partial<{ usuarioId: number; accion: string; entidad: string }> = {};
 
       if (usuarioId !== undefined) {
@@ -77,6 +86,12 @@ export class LogController {
 
       return response.status(200).json(updatedLog);
     } catch (err) {
+      if (err instanceof FechaNoEditableError) {
+        return response
+          .status(400)
+          .json({ error: "El campo fecha no puede modificarse" });
+      }
+
       return response.status(500).json({ error: "Error al actualizar log" });
     }
   }

--- a/src/tests/log.controller.test.ts
+++ b/src/tests/log.controller.test.ts
@@ -75,4 +75,22 @@ describe("LogController.update", () => {
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith({ error: "Log no encontrado" });
   });
+
+  test("debe rechazar intentos de modificar la fecha", async () => {
+    const req = {
+      params: { id: "4" },
+      body: { fecha: new Date().toISOString() },
+    } as unknown as Request;
+    const res = buildResponse();
+
+    const spy = jest.spyOn(LogApplicationService.prototype, "updateLog");
+
+    await LogController.update(req, res);
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "El campo fecha no puede modificarse",
+    });
+  });
 });

--- a/src/tests/log.service.test.ts
+++ b/src/tests/log.service.test.ts
@@ -67,4 +67,11 @@ describe("Pruebas de LogApplicationService", () => {
     expect(mockRepo.updateLog).toHaveBeenCalledWith(99, { accion: "No existe" });
     expect(result).toBeNull();
   });
+
+  test("Debe rechazar la modificación de la fecha", async () => {
+    await expect(
+      service.updateLog(5, { fecha: new Date() } as unknown as any)
+    ).rejects.toThrow("El campo fecha no puede modificarse");
+    expect(mockRepo.updateLog).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- impide que LogController acepte modificaciones del campo `fecha` y devuelve un error descriptivo al intentar hacerlo
- refuerza LogApplicationService para rechazar y sanear el campo `fecha`, cubriendo el comportamiento con pruebas nuevas
- ajusta la documentación (OpenAPI y README) para reflejar los campos realmente editables

## Testing
- `npm test` *(falló: `jest` no está disponible y `npm install` no pudo completarse por error 403 al descargar `sonarqube-scanner`)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5796918883249d5b9e169232477f